### PR TITLE
Allow ODataEntitySetIterator subclasses

### DIFF
--- a/lib/client-api/src/main/java/org/apache/olingo/client/api/domain/ODataEntitySetIterator.java
+++ b/lib/client-api/src/main/java/org/apache/olingo/client/api/domain/ODataEntitySetIterator.java
@@ -56,13 +56,13 @@ public class ODataEntitySetIterator<ES extends CommonODataEntitySet, E extends C
    */
   private static final Logger LOG = LoggerFactory.getLogger(ODataEntitySetIterator.class);
 
-  private final CommonODataClient<?> odataClient;
+  protected final CommonODataClient<?> odataClient;
 
   private final InputStream stream;
 
   private final ODataFormat format;
 
-  private ResWrap<Entity> cached;
+  protected ResWrap<Entity> cached;
 
   private ES entitySet;
 


### PR DESCRIPTION
I have a use case where I need to provide more strongly typed objects than the base `ODataEntity` and thus need to provide a more strongly typed iterator.  In my iterator (not in this pull request) I need access to the `odataClient` and the cached entity as I overload the `next()` method.
