### PR TITLE
OLINGO-799

### DIFF
--- a/lib/server-core/src/main/java/org/apache/olingo/server/core/deserializer/xml/ODataXmlDeserializer.java
+++ b/lib/server-core/src/main/java/org/apache/olingo/server/core/deserializer/xml/ODataXmlDeserializer.java
@@ -66,11 +66,9 @@ import org.apache.olingo.server.api.deserializer.ODataDeserializer;
 import org.apache.olingo.server.api.deserializer.DeserializerException.MessageKeys;
 import org.apache.olingo.server.core.deserializer.DeserializerResultImpl;
 
-import com.fasterxml.aalto.stax.InputFactoryImpl;
-
 public class ODataXmlDeserializer implements ODataDeserializer {
 
-  private static final XMLInputFactory FACTORY = new InputFactoryImpl();
+  private static final XMLInputFactory FACTORY = XMLInputFactory.newInstance();
 
   private static final QName propertiesQName = new QName(Constants.NS_METADATA, Constants.PROPERTIES);
   private static final QName propertyValueQName = new QName(Constants.NS_METADATA, Constants.VALUE);


### PR DESCRIPTION
in olingo4-server removed dependency for aalto-xml implementation of XMLInputFactory (com.fasterxml.aalto.stax.InputFactoryImpl) in favor of using XMLInputFactory.newInstance()