### PR TITLE
Update MetadataParser.java to set appropriate value for Nullable attribute of NavigationProperty

### DIFF
--- a/lib/server-core-ext/src/main/java/org/apache/olingo/server/core/MetadataParser.java
+++ b/lib/server-core-ext/src/main/java/org/apache/olingo/server/core/MetadataParser.java
@@ -915,7 +915,7 @@ public class MetadataParser {
     property.setName(attr(element, "Name"));
     property.setType(readType(element));
     property.setCollection(isCollectionType(element));
-    property.setNullable(Boolean.parseBoolean(attr(element, "Nullable")));
+    property.setNullable(Boolean.parseBoolean(attr(element, "Nullable") == null ? "true" : attr(element, "Nullable")));
     property.setPartner(attr(element, "Partner"));
     property.setContainsTarget(Boolean.parseBoolean(attr(element, "ContainsTarget")));
 


### PR DESCRIPTION
Updated to Set Nullable attribute to "true" as default value for a Navigation property that is not a collection or when a value is not provided