### PR TITLE
removed aalto library direct references in client-core in favor of JAXP

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/serialization/AtomSerializer.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/serialization/AtomSerializer.java
@@ -53,13 +53,11 @@ import org.apache.olingo.commons.api.format.ContentType;
 import org.apache.olingo.commons.core.edm.EdmTypeInfo;
 import org.apache.olingo.commons.core.edm.primitivetype.EdmPrimitiveTypeFactory;
 
-import com.fasterxml.aalto.stax.OutputFactoryImpl;
-
 public class AtomSerializer implements ODataSerializer {
 
   private static final String TYPE_TEXT = "text";
 
-  private static final XMLOutputFactory FACTORY = new OutputFactoryImpl();
+  private static final XMLOutputFactory FACTORY = XMLOutputFactory.newFactory();
 
   private final AtomGeoValueSerializer geoSerializer;
   private final boolean serverMode;

--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/serialization/ClientODataDeserializerImpl.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/serialization/ClientODataDeserializerImpl.java
@@ -21,6 +21,8 @@ package org.apache.olingo.client.core.serialization;
 import java.io.IOException;
 import java.io.InputStream;
 
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.olingo.client.api.data.ResWrap;
@@ -41,8 +43,6 @@ import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeException;
 import org.apache.olingo.commons.api.ex.ODataError;
 import org.apache.olingo.commons.api.format.ContentType;
 
-import com.fasterxml.aalto.stax.InputFactoryImpl;
-import com.fasterxml.aalto.stax.OutputFactoryImpl;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -90,7 +90,7 @@ public class ClientODataDeserializerImpl implements ClientODataDeserializer {
 
   protected XmlMapper getXmlMapper() {
     final XmlMapper xmlMapper = new XmlMapper(
-        new XmlFactory(new InputFactoryImpl(), new OutputFactoryImpl()), new JacksonXmlModule());
+        new XmlFactory(XMLInputFactory.newFactory(), XMLOutputFactory.newFactory()), new JacksonXmlModule());
 
     xmlMapper.setInjectableValues(new InjectableValues.Std().addValue(Boolean.class, Boolean.FALSE));
 


### PR DESCRIPTION
This was already done on the server-core project with JIRA OLINGO-799 so I am hoping its ok to pull this in for client-core as well.
