### PR TITLE
OLINGO-1009 Changing serialization to allow for $levels

### DIFF
--- a/lib/server-core/src/main/java/org/apache/olingo/server/core/serializer/utils/ExpandSelectHelper.java
+++ b/lib/server-core/src/main/java/org/apache/olingo/server/core/serializer/utils/ExpandSelectHelper.java
@@ -121,7 +121,16 @@ public abstract class ExpandSelectHelper {
     }
     return false;
   }
-
+  
+  public static ExpandItem getExpandAll(final ExpandOption expand) {
+      for (final ExpandItem item : expand.getExpandItems()) {
+        if (item.isStar()) {
+          return item;
+        }
+      }
+      return null;
+    }
+  
   public static Set<String> getExpandedPropertyNames(final List<ExpandItem> expandItems)
       throws SerializerException {
     Set<String> expanded = new HashSet<String>();
@@ -137,6 +146,9 @@ public abstract class ExpandSelectHelper {
 
   public static ExpandItem getExpandItem(final List<ExpandItem> expandItems, final String propertyName) {
     for (final ExpandItem item : expandItems) {
+      if (item.isStar()) {
+          continue;
+      }
       final UriResource resource = item.getResourcePath().getUriResourceParts().get(0);
       if (resource instanceof UriResourceNavigation
           && propertyName.equals(((UriResourceNavigation) resource).getProperty().getName())) {


### PR DESCRIPTION
Here's a proposal to support $levels during serialization.  It doesn't enforce an explicit max other than to use Integer max.  It also ensures that explicit property expands take precedence over star expand.