### PR TITLE
include nav link for expanded entity/collection

### DIFF
--- a/lib/server-core/src/main/java/org/apache/olingo/server/core/serializer/json/ODataJsonSerializer.java
+++ b/lib/server-core/src/main/java/org/apache/olingo/server/core/serializer/json/ODataJsonSerializer.java
@@ -564,6 +564,10 @@ public class ODataJsonSerializer extends AbstractODataSerializer {
       final boolean writeOnlyCount, final boolean writeOnlyRef, final Set<String> ancestors,
       final JsonGenerator json) throws IOException, SerializerException {
 
+    if (isODataMetadataFull) {
+      json.writeStringField(property.getName() + Constants.JSON_NAVIGATION_LINK, navigationLink.getHref());
+    }
+    
     if (property.isCollection()) {
       if (writeOnlyCount) {
         if (navigationLink == null || navigationLink.getInlineEntitySet() == null) {


### PR DESCRIPTION
Apologies for the brevity, but I'm new to OData and short on time, and just need to write a mock service to run tests against, mimicking a partner's web service.

I found that with expanded collections, the nav link is not written by the JSON serializer, so hacked this fix in so that the data returned is like that from the partner's web service, and the olingo client will correctly deserialize the expanded collection