### PR TITLE
[OLINGO-278] Update to latest version of HttpClient

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/http/HttpMerge.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/http/HttpMerge.java
@@ -20,13 +20,11 @@ package org.apache.olingo.client.core.http;
 
 import java.net.URI;
 
-import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 
 /**
  * Class identifying MERGE HTTP method.
  */
-@NotThreadSafe
 public class HttpMerge extends HttpEntityEnclosingRequestBase {
 
   public final static String METHOD_NAME = "MERGE";

--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/http/HttpPatch.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/http/HttpPatch.java
@@ -20,13 +20,11 @@ package org.apache.olingo.client.core.http;
 
 import java.net.URI;
 
-import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 
 /**
  * Class identifying PATCH HTTP method.
  */
-@NotThreadSafe
 public class HttpPatch extends HttpEntityEnclosingRequestBase {
 
   public final static String METHOD_NAME = "PATCH";

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <maven.plugin.api.version>3.2.2</maven.plugin.api.version>
     <maven.plugin.tools.version>3.3</maven.plugin.tools.version>
     <maven.bundle.plugin.version>2.5.3</maven.bundle.plugin.version>
-    <hc.client.version>4.2.6</hc.client.version>
-    <hc.core.version>4.2.5</hc.core.version>
+    <hc.client.version>4.5.3</hc.client.version>
+    <hc.core.version>4.4.6</hc.core.version>
     <jackson.version>2.7.8</jackson.version>
     <aalto-xml.version>0.9.10</aalto-xml.version>
 


### PR DESCRIPTION
removed @NotThreadSafe annotation due to HTTPCLIENT-1743, @Contract(threading = ThreadingBehavior.UNSAFE) is now default