### PR TITLE
[OLINGO-1150]support scientific notation in EdmDecimal

### DIFF
--- a/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/primitivetype/EdmDecimal.java
+++ b/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/primitivetype/EdmDecimal.java
@@ -31,7 +31,8 @@ import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeException;
  */
 public final class EdmDecimal extends SingletonPrimitiveType {
 
-  private static final Pattern PATTERN = Pattern.compile("(?:\\+|-)?(?:0*(\\p{Digit}+?))(?:\\.(\\p{Digit}+?)0*)?");
+  private static final Pattern PATTERN = Pattern.compile(
+          "(?:\\+|-)?(?:0*(\\p{Digit}+?))(?:\\.(\\p{Digit}+?)0*)?((?:E|e)(?:\\+|-)?\\p{Digit}+)?");
 
   private static final EdmDecimal INSTANCE = new EdmDecimal();
 

--- a/lib/commons-core/src/test/java/org/apache/olingo/commons/core/edm/primitivetype/EdmDecimalTest.java
+++ b/lib/commons-core/src/test/java/org/apache/olingo/commons/core/edm/primitivetype/EdmDecimalTest.java
@@ -97,7 +97,9 @@ public class EdmDecimalTest extends PrimitiveTypeBaseTest {
     assertEquals(Double.valueOf(0.5), instance.valueOfString("0.5", null, null, 1, 1, null, Double.class));
     assertEquals(Float.valueOf(0.5F), instance.valueOfString("0.5", null, null, null, 1, null, Float.class));
     assertEquals(new BigDecimal("12.3"), instance.valueOfString("12.3", null, null, 3, 1, null, BigDecimal.class));
-
+    assertEquals(new BigDecimal("31991163"), instance.valueOfString("3.1991163E7", null, null, 8, 7, 
+        null, BigDecimal.class));
+    
     expectFacetsErrorInValueOfString(instance, "0.5", null, null, null, null, null);
     expectFacetsErrorInValueOfString(instance, "-1234", null, null, 2, null, null);
     expectFacetsErrorInValueOfString(instance, "1234", null, null, 3, null, null);
@@ -107,7 +109,6 @@ public class EdmDecimalTest extends PrimitiveTypeBaseTest {
     expectFacetsErrorInValueOfString(instance, "0.00390625", null, null, 5, null, null);
     expectFacetsErrorInValueOfString(instance, "0.00390625", null, null, null, 7, null);
 
-    expectContentErrorInValueOfString(instance, "-1E2");
     expectContentErrorInValueOfString(instance, "1.");
     expectContentErrorInValueOfString(instance, ".1");
     expectContentErrorInValueOfString(instance, "1.0.1");


### PR DESCRIPTION
For https://issues.apache.org/jira/browse/OLINGO-1150

The problem is occur when we use Olingo retrieve data from Microsoft Dynamic CRM online 2016.
When decimal field have such kind of data **31991163**. During data extract inside Olingo.
It convert to _3.1991163E7_ by jackson when jackson parse response to json tree.
And EdmDecimal can't support scientific notation.
This really block our envelopment.

So in this pull request. I change pattern to accept scientific notation.

Please help to review the changes.
Thanks in advance!