### PR TITLE
Hack to retrieve properties annotations

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/edm/ClientCsdlEdmProvider.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/edm/ClientCsdlEdmProvider.java
@@ -44,6 +44,7 @@ import org.apache.olingo.commons.api.ex.ODataException;
 
 public class ClientCsdlEdmProvider extends CsdlAbstractEdmProvider {
 
+  public static final String CORE_VOCABULARY_NAMESPACE = "Org.OData.Core.V1";
   private final Map<String, CsdlSchema> xmlSchemas;
 
   public ClientCsdlEdmProvider(Map<String, CsdlSchema> xmlSchemas) {
@@ -110,7 +111,11 @@ public class ClientCsdlEdmProvider extends CsdlAbstractEdmProvider {
     if (schema != null) {
       return schema.getTerm(termName.getName());
     }
-    return null;
+
+    CsdlTerm t = new CsdlTerm();
+    t.setName(termName.getFullQualifiedNameAsString());
+
+    return t;
   }
 
   @Override
@@ -180,6 +185,9 @@ public class ClientCsdlEdmProvider extends CsdlAbstractEdmProvider {
         aliasInfo.add(new CsdlAliasInfo().setNamespace(schema.getNamespace()).setAlias(schema.getAlias()));
       }
     }
+
+    aliasInfo.add(new CsdlAliasInfo().setAlias("Core").setNamespace(CORE_VOCABULARY_NAMESPACE));
+    System.out.println("Add Code alias " + CORE_VOCABULARY_NAMESPACE);
     return aliasInfo;
   }
 

--- a/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmAnnotation.java
+++ b/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmAnnotation.java
@@ -19,6 +19,7 @@
 package org.apache.olingo.commons.api.edm;
 
 import org.apache.olingo.commons.api.edm.annotation.EdmExpression;
+import org.apache.olingo.commons.api.edm.provider.CsdlAnnotation;
 
 /**
  * This class models an OData Annotation which can be applied to a target. 
@@ -36,4 +37,6 @@ public interface EdmAnnotation extends EdmAnnotatable {
   String getQualifier();
 
   EdmExpression getExpression();
+
+  CsdlAnnotation getAnnotation();
 }

--- a/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmAnnotationImpl.java
+++ b/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmAnnotationImpl.java
@@ -38,6 +38,10 @@ public class EdmAnnotationImpl extends AbstractEdmAnnotatable implements EdmAnno
     this.annotation = annotation;
   }
 
+  public CsdlAnnotation getAnnotation(){
+    return annotation;
+  }
+
   @Override
   public EdmTerm getTerm() {
     if (term == null) {

--- a/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmProviderImpl.java
+++ b/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmProviderImpl.java
@@ -379,7 +379,7 @@ public class EdmProviderImpl extends AbstractEdm {
   @Override
   protected EdmTerm createTerm(final FullQualifiedName termName) {
     try {
-      CsdlTerm providerTerm = provider.getTerm(termName);
+      CsdlTerm providerTerm = provider.getTerm(termName); // ICI
       if (providerTerm != null) {
         return new EdmTermImpl(this, termName.getNamespace(), providerTerm);
       } else if (termSchemaDefinition != null && termSchemaDefinition.size() > 0) {


### PR DESCRIPTION
Some hack to retrieve properties annotations of entities. This is due to odata client don't load 'Org.OData.Core.V1" name space  (or make an alias on 'Core' as in server side)