### PR TITLE
export org.apache.olingo.server.core.uri.parser in OSGI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .classpath
 .settings
 .idea
+*.iml
 target
 bin
 *.bak

--- a/lib/server-core/pom.xml
+++ b/lib/server-core/pom.xml
@@ -105,7 +105,8 @@
             <Implementation-Version>${project.version}</Implementation-Version>
             <Implementation-Title>${project.name}</Implementation-Title>
             <Export-Package>
-              org.apache.olingo.server.core
+              org.apache.olingo.server.core,
+              org.apache.olingo.server.core.uri.parser
             </Export-Package>
             <Import-Package>
               *


### PR DESCRIPTION
Seems reasonable to export the _org.apache.olingo.server.core.uri.parser_ package in OSGI. We [use](https://github.com/apache/camel/blob/59dd93c02f0bdb1a5682c08ad02101341d91d773/components/camel-olingo4/camel-olingo4-api/src/main/java/org/apache/camel/component/olingo4/api/impl/Olingo4AppImpl.java#L803) it in Apache Camel to properly retrieve the UriInfo.