### PR TITLE
OLINGO-1350: Updating fasterxml to 2.9.8 and removing aalto-xml library

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/edm/xml/ClientCsdlEdmx.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/edm/xml/ClientCsdlEdmx.java
@@ -76,7 +76,7 @@ public class ClientCsdlEdmx extends CsdlAbstractEdmItem implements Serializable,
 
       final ClientCsdlEdmx edmx = new ClientCsdlEdmx();
 
-      for (; jp.getCurrentToken() != JsonToken.END_OBJECT; jp.nextToken()) {
+      for (; (jp.getCurrentToken() != null && jp.getCurrentToken() != JsonToken.END_OBJECT); jp.nextToken()) {
         final JsonToken token = jp.getCurrentToken();
         if (token == JsonToken.FIELD_NAME) {
           if ("Version".equals(jp.getCurrentName())) {

--- a/lib/server-core-ext/src/test/java/org/apache/olingo/server/example/TripPinServiceTest.java
+++ b/lib/server-core-ext/src/test/java/org/apache/olingo/server/example/TripPinServiceTest.java
@@ -125,10 +125,11 @@ public class TripPinServiceTest {
         "<m:properties>"
         +     "<d:AirlineCode>FM</d:AirlineCode>"
         +     "<d:Name>Shanghai xxxAirlinexxx</d:Name>" 
-        +     "<d:Picture m:null=\"true\"/>" 
+        +     "<d:Picture m:null=\"true\"></d:Picture>" 
         +  "</m:properties>"  
         + "</a:content>"  
         +"</a:entry>";
+    System.out.println(actual);
     assertTrue(actual.endsWith(expected));
   }
 

--- a/lib/server-core/pom.xml
+++ b/lib/server-core/pom.xml
@@ -60,15 +60,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-
-	<dependency>
-      <groupId>com.fasterxml</groupId>
-      <artifactId>aalto-xml</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/lib/server-core/src/test/java/org/apache/olingo/server/core/serializer/xml/MetadataDocumentXmlSerializerTest.java
+++ b/lib/server-core/src/test/java/org/apache/olingo/server/core/serializer/xml/MetadataDocumentXmlSerializerTest.java
@@ -118,9 +118,9 @@ public class MetadataDocumentXmlSerializerTest {
     ServiceMetadata metadata = mock(ServiceMetadata.class);
     when(metadata.getEdm()).thenReturn(edm);
 
-    assertEquals("<?xml version='1.0' encoding='UTF-8'?>"
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">"
-        + "<edmx:DataServices/></edmx:Edmx>",
+        + "<edmx:DataServices></edmx:DataServices></edmx:Edmx>",
         IOUtils.toString(serializer.metadataDocument(metadata).getContent()));
   }
 
@@ -136,10 +136,10 @@ public class MetadataDocumentXmlSerializerTest {
 
     InputStream metadata = serializer.metadataDocument(serviceMetadata).getContent();
     assertNotNull(metadata);
-    assertEquals("<?xml version='1.0' encoding='UTF-8'?>"
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">"
         + "<edmx:DataServices>"
-        + "<Schema xmlns=\"http://docs.oasis-open.org/odata/ns/edm\" Namespace=\"MyNamespace\"/>"
+        + "<Schema xmlns=\"http://docs.oasis-open.org/odata/ns/edm\" Namespace=\"MyNamespace\"></Schema>"
         + "</edmx:DataServices>"
         + "</edmx:Edmx>",
         IOUtils.toString(metadata));
@@ -262,41 +262,44 @@ public class MetadataDocumentXmlSerializerTest {
     final String metadataString = IOUtils.toString(metadata);
     // edmx reference
     assertTrue(metadataString.contains(
-        "<edmx:Reference Uri=\"http://example.com\"/>"));
+        "<edmx:Reference Uri=\"http://example.com\"></edmx:Reference>"));
     assertTrue(metadataString.contains(
         "<edmx:Reference " +
             "Uri=\"http://localhost/odata/odata/v4.0/referenceWithInclude\">" +
-            "<edmx:Include Namespace=\"Org.OData.Core.V1\" Alias=\"Core\"/>" +
+            "<edmx:Include Namespace=\"Org.OData.Core.V1\" Alias=\"Core\"></edmx:Include>" +
         "</edmx:Reference>"));
     assertTrue(metadataString.contains(
         "<edmx:Reference " +
             "Uri=\"http://localhost/odata/odata/v4.0/referenceWithTwoIncludes\">" +
-            "<edmx:Include Namespace=\"Org.OData.Core.2\" Alias=\"Core2\"/>" +
-            "<edmx:Include Namespace=\"Org.OData.Core.3\" Alias=\"Core3\"/>" +
+            "<edmx:Include Namespace=\"Org.OData.Core.2\" Alias=\"Core2\"></edmx:Include>" +
+            "<edmx:Include Namespace=\"Org.OData.Core.3\" Alias=\"Core3\"></edmx:Include>" +
         "</edmx:Reference>"));
     assertTrue(metadataString.contains(
         "<edmx:Reference Uri=\"http://localhost/odata/odata/v4.0/referenceWithIncludeAnnos\">" +
-            "<edmx:IncludeAnnotations TermNamespace=\"TermNs.2\" Qualifier=\"Q.2\" TargetNamespace=\"TargetNS.2\"/>" +
-            "<edmx:IncludeAnnotations TermNamespace=\"TermNs.3\" Qualifier=\"Q.3\" TargetNamespace=\"TargetNS.3\"/>" +
+            "<edmx:IncludeAnnotations TermNamespace=\"TermNs.2\" Qualifier=\"Q.2\" "
+            + "TargetNamespace=\"TargetNS.2\"></edmx:IncludeAnnotations>" +
+            "<edmx:IncludeAnnotations TermNamespace=\"TermNs.3\" Qualifier=\"Q.3\" "
+            + "TargetNamespace=\"TargetNS.3\"></edmx:IncludeAnnotations>" +
         "</edmx:Reference>"));
     assertTrue(metadataString.contains(
-        "<edmx:Reference Uri=\"http://localhost/odata/odata/v4.0/referenceWithAll\">" +
-            "<edmx:Include Namespace=\"ReferenceWithAll.1\" Alias=\"Core1\"/>" +
-            "<edmx:Include Namespace=\"ReferenceWithAll.2\" Alias=\"Core2\"/>" +
-            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermNs.4\" " +
-            "Qualifier=\"Q.4\" TargetNamespace=\"TargetNS.4\"/>" +
-            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermNs.5\" " +
-            "Qualifier=\"Q.5\" TargetNamespace=\"TargetNS.5\"/>" +
-        "</edmx:Reference>"));
+            "<edmx:Reference Uri=\"http://localhost/odata/odata/v4.0/referenceWithAll\">" +
+                "<edmx:Include Namespace=\"ReferenceWithAll.1\" Alias=\"Core1\"></edmx:Include>" +
+                "<edmx:Include Namespace=\"ReferenceWithAll.2\" Alias=\"Core2\"></edmx:Include>" +
+                "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermNs.4\" " +
+                "Qualifier=\"Q.4\" TargetNamespace=\"TargetNS.4\"></edmx:IncludeAnnotations>" +
+                "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermNs.5\" " +
+                "Qualifier=\"Q.5\" TargetNamespace=\"TargetNS.5\"></edmx:IncludeAnnotations>" +
+            "</edmx:Reference>"));
     assertTrue(metadataString.contains(
         "<edmx:Reference Uri=\"http://localhost/odata/odata/v4.0/referenceWithAllAndNull\">" +
-            "<edmx:Include Namespace=\"referenceWithAllAndNull.1\"/>" +
-            "<edmx:Include Namespace=\"referenceWithAllAndNull.2\"/>" +
-            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermNs.4\"/>" +
-            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermAndNullNs.5\" Qualifier=\"Q.5\"/>" +
+            "<edmx:Include Namespace=\"referenceWithAllAndNull.1\"></edmx:Include>" +
+            "<edmx:Include Namespace=\"referenceWithAllAndNull.2\"></edmx:Include>" +
+            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermNs.4\"></edmx:IncludeAnnotations>" +
+            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermAndNullNs.5\" " +
+            "Qualifier=\"Q.5\"></edmx:IncludeAnnotations>" +
             "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermAndNullNs.6\" " +
-            "TargetNamespace=\"TargetNS\"/>" +
-            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermAndNullNs.7\"/>" +
+            "TargetNamespace=\"TargetNS\"></edmx:IncludeAnnotations>" +
+            "<edmx:IncludeAnnotations TermNamespace=\"ReferenceWithAllTermAndNullNs.7\"></edmx:IncludeAnnotations>" +
         "</edmx:Reference>"));
   }
 
@@ -306,24 +309,25 @@ public class MetadataDocumentXmlSerializerTest {
 
     assertTrue(metadata.contains("<EnumType Name=\"ENString\" IsFlags=\"true\" UnderlyingType=\"Edm.Int16\">"));
     assertTrue(metadata.contains("<EntityType Name=\"ETAbstractBase\" BaseType=\"Alias.ETAbstract\">"));
-    assertTrue(metadata.contains("<ComplexType Name=\"CTTwoPrimBase\" BaseType=\"Alias.CTTwoPrim\"/>"));
-    assertTrue(metadata.contains("<Property Name=\"PropertyInt16\" Type=\"Edm.Int16\" Nullable=\"false\"/>"));
-    assertTrue(metadata.contains("<EntitySet Name=\"ESAllPrim\" EntityType=\"Alias.ETAbstractBase\"/>"));
-    assertTrue(metadata.contains("<Singleton Name=\"SI\" Type=\"Alias.ETAbstractBase\"/>"));
-    assertTrue(metadata.contains("<ActionImport Name=\"AIRTPrimParam\" Action=\"Alias.UARTPrimParam\"/>"));
+    assertTrue(metadata.contains("<ComplexType Name=\"CTTwoPrimBase\" BaseType=\"Alias.CTTwoPrim\"></ComplexType>"));
+    assertTrue(metadata.contains("<Property Name=\"PropertyInt16\" Type=\"Edm.Int16\" Nullable=\"false\"></Property>"));
+    assertTrue(metadata.contains("<EntitySet Name=\"ESAllPrim\" EntityType=\"Alias.ETAbstractBase\"></EntitySet>"));
+    assertTrue(metadata.contains("<Singleton Name=\"SI\" Type=\"Alias.ETAbstractBase\"></Singleton>"));
+    assertTrue(metadata.contains("<ActionImport Name=\"AIRTPrimParam\" Action=\"Alias.UARTPrimParam\"></ActionImport"));
     assertTrue(metadata.contains("<FunctionImport Name=\"FINRTInt16\" " +
-        "Function=\"Alias.UFNRTInt16\" IncludeInServiceDocument=\"true\"/>"));
+        "Function=\"Alias.UFNRTInt16\" IncludeInServiceDocument=\"true\"></FunctionImport>"));
   }
 
   @Test
   public void terms() throws Exception {
     String metadata = localMetadata();
-    assertTrue(metadata.contains("<Term Name=\"Term1\" Type=\"Edm.String\"/>"));
+    assertTrue(metadata.contains("<Term Name=\"Term1\" Type=\"Edm.String\"></Term>"));
     assertTrue(metadata
         .contains("<Term Name=\"Term2\" Type=\"Edm.String\" Nullable=\"false\" DefaultValue=\"default\" "
-            + "MaxLength=\"1\" Precision=\"2\" Scale=\"3\"/>"));
-    assertTrue(metadata.contains("<Term Name=\"Term3\" Type=\"Edm.String\" AppliesTo=\"Property EntitySet Schema\"/>"));
-    assertTrue(metadata.contains("<Term Name=\"Term4\" Type=\"Edm.String\" BaseTerm=\"Alias.Term1\"/>"));
+            + "MaxLength=\"1\" Precision=\"2\" Scale=\"3\"></Term>"));
+    assertTrue(metadata.contains("<Term Name=\"Term3\" Type=\"Edm.String\" "
+    		+ "AppliesTo=\"Property EntitySet Schema\"></Term>"));
+    assertTrue(metadata.contains("<Term Name=\"Term4\" Type=\"Edm.String\" BaseTerm=\"Alias.Term1\"></Term>"));
   }
 
   @Test
@@ -351,44 +355,55 @@ public class MetadataDocumentXmlSerializerTest {
 
     // All dynamic expressions
     // Logical expressions
-    assertTrue(metadata.contains("<And><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></And>"));
-    assertTrue(metadata.contains("<Or><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Or>"));
-    assertTrue(metadata.contains("<Not><Bool>true</Bool><Annotation Term=\"ns.term\"/></Not>"));
+    assertTrue(metadata.contains("<And><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></And>"));
+    assertTrue(metadata.contains("<Or><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Or>"));
+    assertTrue(metadata.contains("<Not><Bool>true</Bool><Annotation Term=\"ns.term\"></Annotation></Not>"));
 
     // Comparison expressions
-    assertTrue(metadata.contains("<Eq><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Eq>"));
-    assertTrue(metadata.contains("<Ne><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Ne>"));
-    assertTrue(metadata.contains("<Gt><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Gt>"));
-    assertTrue(metadata.contains("<Ge><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Ge>"));
-    assertTrue(metadata.contains("<Lt><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Lt>"));
-    assertTrue(metadata.contains("<Le><Bool>true</Bool><Bool>false</Bool><Annotation Term=\"ns.term\"/></Le>"));
+    assertTrue(metadata.contains("<Eq><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Eq>"));
+    assertTrue(metadata.contains("<Ne><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Ne>"));
+    assertTrue(metadata.contains("<Gt><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Gt>"));
+    assertTrue(metadata.contains("<Ge><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Ge>"));
+    assertTrue(metadata.contains("<Lt><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Lt>"));
+    assertTrue(metadata.contains("<Le><Bool>true</Bool><Bool>false</Bool>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></Le>"));
 
     // Other
     assertTrue(metadata.contains("<AnnotationPath>AnnoPathValue</AnnotationPath>"));
     assertTrue(metadata
-        .contains("<Apply Function=\"odata.concat\"><Bool>true</Bool><Annotation Term=\"ns.term\"/></Apply>"));
+        .contains("<Apply Function=\"odata.concat\"><Bool>true</Bool>"
+        		+ "<Annotation Term=\"ns.term\"></Annotation></Apply>"));
     assertTrue(metadata
         .contains("<Cast Type=\"Edm.String\" MaxLength=\"1\" Precision=\"2\" Scale=\"3\">"
-            + "<String>value</String><Annotation Term=\"ns.term\"/></Cast>"));
+            + "<String>value</String><Annotation Term=\"ns.term\"></Annotation></Cast>"));
     assertTrue(metadata.contains("<Collection><Bool>true</Bool>"
         + "<Bool>false</Bool><String>String</String></Collection>"));
     assertTrue(metadata
         .contains("<If><Bool>true</Bool><String>Then</String>"
-            + "<String>Else</String><Annotation Term=\"ns.term\"/></If>"));
+            + "<String>Else</String><Annotation Term=\"ns.term\"></Annotation></If>"));
     assertTrue(metadata
         .contains("<IsOf Type=\"Edm.String\" MaxLength=\"1\" Precision=\"2\" Scale=\"3\">"
-            + "<String>value</String><Annotation Term=\"ns.term\"/></IsOf>"));
+            + "<String>value</String><Annotation Term=\"ns.term\"></Annotation></IsOf>"));
     assertTrue(metadata
         .contains("<LabeledElement Name=\"NameAtt\">"
-            + "<String>value</String><Annotation Term=\"ns.term\"/></LabeledElement>"));
+            + "<String>value</String><Annotation Term=\"ns.term\"></Annotation></LabeledElement>"));
     assertTrue(metadata.contains("<LabeledElementReference>LabeledElementReferenceValue</LabeledElementReference>"));
     assertTrue(metadata.contains("<NavigationPropertyPath>NavigationPropertyPathValue</NavigationPropertyPath>"));
     assertTrue(metadata.contains("<Path>PathValue</Path>"));
     assertTrue(metadata.contains("<PropertyPath>PropertyPathValue</PropertyPath>"));
     assertTrue(metadata
         .contains("<Record Type=\"Alias.ETAbstract\"><PropertyValue Property=\"PropName\"><String>value</String>"
-            + "<Annotation Term=\"ns.term\"/></PropertyValue><Annotation Term=\"ns.term\"/></Record>"));
-    assertTrue(metadata.contains("<UrlRef><String>URLRefValue</String><Annotation Term=\"ns.term\"/></UrlRef>"));
+            + "<Annotation Term=\"ns.term\"></Annotation></PropertyValue>"
+            + "<Annotation Term=\"ns.term\"></Annotation></Record>"));
+    assertTrue(metadata.contains("<UrlRef><String>URLRefValue</String>"
+    		+ "<Annotation Term=\"ns.term\"></Annotation></UrlRef>"));
 
   }
 
@@ -451,8 +466,8 @@ public class MetadataDocumentXmlSerializerTest {
     InputStream metadataStream = serializer.metadataDocument(serviceMetadata).getContent();
     String metadata = IOUtils.toString(metadataStream);
     assertTrue(metadata.contains("<ComplexType Name=\"ComplexType\" Abstract=\"true\" OpenType=\"true\">"
-        + "<Property Name=\"prop1\" Type=\"Edm.String\"/>"
-        + "<Property Name=\"prop2\" Type=\"Edm.String\"/>"
+        + "<Property Name=\"prop1\" Type=\"Edm.String\"></Property>"
+        + "<Property Name=\"prop2\" Type=\"Edm.String\"></Property>"
         + "</ComplexType>"));
   }
 

--- a/lib/server-core/src/test/java/org/apache/olingo/server/core/serializer/xml/ServerErrorXmlSerializerTest.java
+++ b/lib/server-core/src/test/java/org/apache/olingo/server/core/serializer/xml/ServerErrorXmlSerializerTest.java
@@ -46,7 +46,7 @@ public class ServerErrorXmlSerializerTest {
     error.setCode("Code").setMessage("ErrorMessage");
     InputStream stream = ser.error(error).getContent();
     String jsonString = IOUtils.toString(stream);
-    assertEquals("<?xml version='1.0' encoding='UTF-8'?>"
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<error xmlns=\"http://docs.oasis-open.org/odata/ns/metadata\">"
         + "<code>Code</code>"
         + "<message>ErrorMessage</message>"
@@ -72,7 +72,7 @@ public class ServerErrorXmlSerializerTest {
 
     InputStream stream = ser.error(error).getContent();
     String jsonString = IOUtils.toString(stream);
-    assertEquals("<?xml version='1.0' encoding='UTF-8'?>"
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<error xmlns=\"http://docs.oasis-open.org/odata/ns/metadata\">"
         + "<code>code</code>"
         + "<message>err message</message>"

--- a/lib/server-core/src/test/java/org/apache/olingo/server/core/serializer/xml/ServiceDocumentXmlSerializerTest.java
+++ b/lib/server-core/src/test/java/org/apache/olingo/server/core/serializer/xml/ServiceDocumentXmlSerializerTest.java
@@ -63,7 +63,7 @@ public class ServiceDocumentXmlSerializerTest {
     ServiceMetadata metadata = mock(ServiceMetadata.class);
     when(metadata.getEdm()).thenReturn(edm);
 
-    assertEquals("<?xml version='1.0' encoding='UTF-8'?>"
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<app:service xmlns:atom=\"http://www.w3.org/2005/Atom\" "
         + "xmlns:app=\"http://www.w3.org/2007/app\" "
         + "xmlns:metadata=\"http://docs.oasis-open.org/odata/ns/metadata\" "
@@ -80,7 +80,7 @@ public class ServiceDocumentXmlSerializerTest {
         Collections.<EdmxReference> emptyList(), null);
     InputStream metadataStream = serializer.serviceDocument(serviceMetadata, "http://host/svc").getContent();
     String metadata = IOUtils.toString(metadataStream);
-    assertEquals("<?xml version='1.0' encoding='UTF-8'?>"
+    assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<app:service xmlns:atom=\"http://www.w3.org/2005/Atom\" "
         + "xmlns:app=\"http://www.w3.org/2007/app\" "
         + "xmlns:metadata=\"http://docs.oasis-open.org/odata/ns/metadata\" "

--- a/lib/server-test/src/test/java/org/apache/olingo/server/core/serializer/xml/MetadataDocumentTest.java
+++ b/lib/server-test/src/test/java/org/apache/olingo/server/core/serializer/xml/MetadataDocumentTest.java
@@ -52,7 +52,7 @@ public class MetadataDocumentTest {
         odata.createSerializer(ContentType.APPLICATION_XML).metadataDocument(serviceMetadata).getContent());
     assertNotNull(metadata);
     assertThat(metadata, containsString("<edmx:Reference Uri=\"" + CORE_VOCABULARY + "\">"
-            + "<edmx:Include Namespace=\"Org.OData.Core.V1\" Alias=\"Core\"/>" + "</edmx:Reference>"));
+            + "<edmx:Include Namespace=\"Org.OData.Core.V1\" Alias=\"Core\"></edmx:Include>" + "</edmx:Reference>"));
 
     assertThat(metadata,
         containsString("<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">"));
@@ -64,18 +64,20 @@ public class MetadataDocumentTest {
     assertThat(metadata,
         containsString("<EntityType Name=\"ETTwoPrim\">"
             + "<Key><PropertyRef Name=\"PropertyInt16\"/></Key>"
-            + "<Property Name=\"PropertyInt16\" Type=\"Edm.Int16\" Nullable=\"false\"/>"
-            + "<Property Name=\"PropertyString\" Type=\"Edm.String\"/>"
-            + "<NavigationProperty Name=\"NavPropertyETAllPrimOne\" Type=\"Namespace1_Alias.ETAllPrim\"/>"
+            + "<Property Name=\"PropertyInt16\" Type=\"Edm.Int16\" Nullable=\"false\"></Property>"
+            + "<Property Name=\"PropertyString\" Type=\"Edm.String\"></Property>"
+            + "<NavigationProperty Name=\"NavPropertyETAllPrimOne\" Type=\"Namespace1_Alias.ETAllPrim\">"
+            + "</NavigationProperty>"
             + "<NavigationProperty Name=\"NavPropertyETAllPrimMany\" "
-            + "Type=\"Collection(Namespace1_Alias.ETAllPrim)\"/>"
+            + "Type=\"Collection(Namespace1_Alias.ETAllPrim)\"></NavigationProperty>"
             + "</EntityType>"));
 
     assertThat(metadata,
         containsString("<EntityType Name=\"ETBase\" BaseType=\"Namespace1_Alias.ETTwoPrim\">"
-            + "<Property Name=\"AdditionalPropertyString_5\" Type=\"Edm.String\"/>"
+            + "<Property Name=\"AdditionalPropertyString_5\" Type=\"Edm.String\"></Property>"
             + "</EntityType>"));
 
+      System.out.println(metadata);
       assertThat(metadata, containsString("<EntitySet Name=\"ESAllPrim\" EntityType=\"Namespace1_Alias.ETAllPrim\">"
         + "<NavigationPropertyBinding Path=\"NavPropertyETTwoPrimOne\" Target=\"ESTwoPrim\"/>"
         + "<NavigationPropertyBinding Path=\"NavPropertyETTwoPrimMany\" Target=\"ESTwoPrim\"/>"
@@ -83,20 +85,20 @@ public class MetadataDocumentTest {
 
     assertThat(metadata,
         containsString("<ComplexType Name=\"CTPrim\">"
-            + "<Property Name=\"PropertyInt16\" Type=\"Edm.Int16\"/></ComplexType>"));
+            + "<Property Name=\"PropertyInt16\" Type=\"Edm.Int16\"></Property></ComplexType>"));
 
     assertThat(metadata,
         containsString("<ComplexType Name=\"CTBase\" BaseType=\"Namespace1_Alias.CTTwoPrim\">"
-            + "<Property Name=\"AdditionalPropString\" Type=\"Edm.String\"/></ComplexType>"));
+            + "<Property Name=\"AdditionalPropString\" Type=\"Edm.String\"></Property></ComplexType>"));
 
     assertThat(metadata, containsString("<Action Name=\"UARTCTTwoPrimParam\" IsBound=\"false\">"
-        + "<Parameter Name=\"ParameterInt16\" Type=\"Edm.Int16\" Nullable=\"false\"/>"
+        + "<Parameter Name=\"ParameterInt16\" Type=\"Edm.Int16\" Nullable=\"false\"></Parameter>"
         + "<ReturnType Type=\"Namespace1_Alias.CTTwoPrim\" Nullable=\"false\"/></Action>"));
     
     assertThat(metadata,
         containsString("<Action Name=\"BAESAllPrimRTETAllPrim\" IsBound=\"true\">"
             + "<Parameter Name=\"ParameterESAllPrim\" "
-            + "Type=\"Collection(Namespace1_Alias.ETAllPrim)\" Nullable=\"false\"/>"
+            + "Type=\"Collection(Namespace1_Alias.ETAllPrim)\" Nullable=\"false\"></Parameter>"
             + "<ReturnType Type=\"Namespace1_Alias.ETAllPrim\"/></Action>"));
 
     assertThat(metadata,
@@ -107,8 +109,9 @@ public class MetadataDocumentTest {
         containsString("<Function Name=\"BFC_RTESTwoKeyNav_\" "
             + "EntitySetPath=\"BindingParam/NavPropertyETTwoKeyNavMany\" IsBound=\"true\" IsComposable=\"true\">"
             + "<Parameter Name=\"BindingParam\" Type=\"Collection(Namespace1_Alias.ETTwoKeyNav)\" "
-            + "Nullable=\"false\"/>"
-            + "<ReturnType Type=\"Collection(Namespace1_Alias.ETTwoKeyNav)\" Nullable=\"false\"/></Function>"));
+            + "Nullable=\"false\"></Parameter>"
+            + "<ReturnType Type=\"Collection(Namespace1_Alias.ETTwoKeyNav)\" Nullable=\"false\"/>"
+            + "</Function>"));
 
     assertThat(metadata, containsString("<EntityContainer Name=\"Container\">"));
 
@@ -123,10 +126,12 @@ public class MetadataDocumentTest {
             + "</Singleton>"));
 
     assertThat(metadata,
-        containsString("<ActionImport Name=\"AIRTCTTwoPrimParam\" Action=\"Namespace1_Alias.UARTCTTwoPrimParam\"/>"));
+        containsString("<ActionImport Name=\"AIRTCTTwoPrimParam\" Action=\"Namespace1_Alias.UARTCTTwoPrimParam\">"
+        		+ "</ActionImport>"));
 
     assertThat(metadata,
-        containsString("<FunctionImport Name=\"FINInvisible2RTInt16\" Function=\"Namespace1_Alias.UFNRTInt16\"/>"));
+        containsString("<FunctionImport Name=\"FINInvisible2RTInt16\" Function=\"Namespace1_Alias.UFNRTInt16\">"
+        		+ "</FunctionImport"));
 
     assertThat(
         metadata,
@@ -140,8 +145,9 @@ public class MetadataDocumentTest {
 
     // TypeDefCheck
     assertThat(metadata,
-        containsString("<Property Name=\"PropertyDefString\" Type=\"Namespace1_Alias.TDString\"/>"));
+        containsString("<Property Name=\"PropertyDefString\" Type=\"Namespace1_Alias.TDString\"></Property>"));
     assertThat(metadata,
-        containsString("<Property Name=\"CollPropertyDefString\" Type=\"Collection(Namespace1_Alias.TDString)\"/>"));
+        containsString("<Property Name=\"CollPropertyDefString\" Type=\"Collection(Namespace1_Alias.TDString)\">"
+        		+ "</Property>"));
   }
 }

--- a/lib/server-test/src/test/java/org/apache/olingo/server/core/serializer/xml/ODataXmlSerializerTest.java
+++ b/lib/server-test/src/test/java/org/apache/olingo/server/core/serializer/xml/ODataXmlSerializerTest.java
@@ -437,7 +437,7 @@ public class ODataXmlSerializerTest {
             .count(countOption)
             .build()).getContent();
     final String resultString = IOUtils.toString(result);
-    String prefix = "<?xml version='1.0' encoding='UTF-8'?>"
+    String prefix = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<a:feed xmlns:a=\"http://www.w3.org/2005/Atom\" "
         + "xmlns:m=\"http://docs.oasis-open.org/odata/ns/metadata\" "
         + "xmlns:d=\"http://docs.oasis-open.org/odata/ns/data\" "
@@ -445,9 +445,9 @@ public class ODataXmlSerializerTest {
         + "m:metadata-etag=\"metadataETag\">"
         + "<a:id>http://host/svc/ESCompAllPrim</a:id>"
         + "<m:count>4</m:count>"
-        + "<a:link rel=\"next\" href=\"/next\"/>"
+        + "<a:link rel=\"next\" href=\"/next\"></a:link>"
         + "<a:entry m:etag=\"W/&quot;32767&quot;\">"
-        + "<a:id>ESCompAllPrim(32767)</a:id><a:title/><a:summary/>";
+        + "<a:id>ESCompAllPrim(32767)</a:id><a:title></a:title><a:summary></a:summary>";
     Assert.assertTrue(resultString.startsWith(prefix));
   }
 
@@ -2643,7 +2643,7 @@ public class ODataXmlSerializerTest {
                     .build())
                 .build()).getContent());
 
-    String expected = "<?xml version='1.0' encoding='UTF-8'?>"
+    String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<m:value xmlns:m=\"http://docs.oasis-open.org/odata/ns/metadata\" "
         + "m:context=\"../$metadata#ESAllPrim(32767)/PropertyString\" "
         + "m:metadata-etag=\"metadataETag\">"
@@ -2667,7 +2667,7 @@ public class ODataXmlSerializerTest {
                 .unicode(Boolean.TRUE)
                 .build()).getContent());
 
-    String expected = "<?xml version='1.0' encoding='UTF-8'?>"
+    String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<m:value xmlns:m=\"http://docs.oasis-open.org/odata/ns/metadata\" "
         + "m:context=\"../$metadata#ESAllPrim(32767)/PropertyString\" "
         + "m:metadata-etag=\"metadataETag\">"
@@ -2687,11 +2687,11 @@ public class ODataXmlSerializerTest {
                 .entitySet(edmEntitySet).keyPath("4242").navOrPropertyPath(edmProperty.getName())
                 .build())
             .build()).getContent());
-    String expected = "<?xml version='1.0' encoding='UTF-8'?>"
+    String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<m:value xmlns:m=\"http://docs.oasis-open.org/odata/ns/metadata\" "
         + "m:context=\"../$metadata#ESAllPrim(4242)/PropertyString\" "
         + "m:metadata-etag=\"metadataETag\" "
-        + "m:null=\"true\"/>";
+        + "m:null=\"true\"></m:value>";
     Assert.assertEquals(expected, response);
   }
 
@@ -3319,7 +3319,7 @@ public class ODataXmlSerializerTest {
                     .navOrPropertyPath("CollPropertyComp")
                     .build()).select(selectOption)
                 .build()).getContent());
-    final String expectedResult = "<?xml version='1.0' encoding='UTF-8'?>"
+    final String expectedResult = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<m:value xmlns:m=\"http://docs.oasis-open.org/odata/ns/metadata\" "
         + "xmlns:d=\"http://docs.oasis-open.org/odata/ns/data\" xmlns:a=\"http://www.w3.org/2005/Atom\" "
         + "m:type=\"#Collection(olingo.odata.test1.CTPrimComp)\" "

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven.bundle.plugin.version>2.5.3</maven.bundle.plugin.version>
     <hc.client.version>4.2.6</hc.client.version>
     <hc.core.version>4.2.5</hc.core.version>
-    <jackson.version>2.7.8</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <aalto-xml.version>0.9.10</aalto-xml.version>
 
     <android.platform.version>4.1.1.4</android.platform.version>
@@ -580,6 +580,7 @@
                 <exclude>**/ref/**</exclude>
                 <exclude>**/server-ref/**</exclude>
                 <exclude>**/dependency-reduced-pom.xml</exclude>
+                <exclude>**/.settings/**</exclude>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
OLINGO-1350: Updating fasterxml version 2.9.8 and removing the dependency on aalto-xml library