### PR TITLE
OLINGO-1357 use s map to cache EdmPrimitiveTypeKind values for lookup

### DIFF
--- a/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmPrimitiveTypeKind.java
+++ b/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmPrimitiveTypeKind.java
@@ -18,6 +18,10 @@
  */
 package org.apache.olingo.commons.api.edm;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Enumeration of all primitive type kinds.
  */
@@ -56,6 +60,26 @@ public enum EdmPrimitiveTypeKind {
   GeometryMultiLineString,
   GeometryMultiPolygon,
   GeometryCollection;
+
+  private static Map<String, EdmPrimitiveTypeKind> VALUES_BY_NAME;
+
+  static {
+    Map<String, EdmPrimitiveTypeKind> valuesByName = new HashMap<java.lang.String, EdmPrimitiveTypeKind>();
+    for (EdmPrimitiveTypeKind value : values()) {
+      valuesByName.put(value.name(), value);
+    }
+    VALUES_BY_NAME = Collections.unmodifiableMap(valuesByName);
+  }
+
+  /**
+   * Get a type kind by name.
+   *
+   * @param name The name.
+   * @return The type kind or <tt>null</tt> if it does not exist.
+   */
+  public static EdmPrimitiveTypeKind getByName(String name) {
+    return VALUES_BY_NAME.get(name);
+  }
 
   /**
    * Checks if is a geospatial type.

--- a/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmTypeInfo.java
+++ b/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmTypeInfo.java
@@ -109,11 +109,8 @@ public class EdmTypeInfo {
 
     fullQualifiedName = new FullQualifiedName(namespace, typeName);
 
-    try {
-      primitiveType = EdmPrimitiveTypeKind.valueOf(typeName);
-    } catch (final IllegalArgumentException e) {
-      primitiveType = null;
-    }
+    primitiveType = EdmPrimitiveTypeKind.getByName(typeName);
+
     if (primitiveType == null && edm != null) {
       typeDefinition = edm.getTypeDefinition(fullQualifiedName);
       if (typeDefinition == null) {


### PR DESCRIPTION
This PR contains a fix for the expensive construction of EdmTypeInfo as described in https://issues.apache.org/jira/browse/OLINGO-1357.