### PR TITLE
[OLINGO-1395] Fixed parsing error when ReturnType contains Annotation

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/edm/xml/ClientCsdlReturnType.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/edm/xml/ClientCsdlReturnType.java
@@ -71,6 +71,9 @@ class ClientCsdlReturnType extends CsdlReturnType implements Serializable {
             if (srid != null) {
               returnType.setSrid(SRID.valueOf(srid));
             }
+          } else if ("Annotation".equals(jp.getCurrentName())) {
+            jp.nextToken();
+            returnType.getAnnotations().add(jp.readValueAs(ClientCsdlAnnotation.class));
           }
         }
       }

--- a/lib/client-core/src/test/resources/org/apache/olingo/client/core/$metadata.xml
+++ b/lib/client-core/src/test/resources/org/apache/olingo/client/core/$metadata.xml
@@ -138,7 +138,11 @@
 		<ReturnType Type="SEPMRA_SO_MAN2.I_DraftAdministrativeDataType"/>
 	  </Action>
 	  <Action Name="UARTString" IsBound="false">
-		<ReturnType Type="Edm.String"/>
+		<ReturnType Type="Edm.String">
+			<Annotation Term="Core.Description">
+				<String>The description for this return type</String>
+			</Annotation>
+		</ReturnType>
 	</Action>
 	  <Function Name="_FC_RTTimeOfDay_" IsBound="true" IsComposable="true">
 		<Parameter Name="ParameterTimeOfDay" Type="Edm.TimeOfDay" Nullable="false"/>


### PR DESCRIPTION
This fixes [[OLINGO-1395]](https://issues.apache.org/jira/browse/OLINGO-1395), includes modification to test case to cover this fix.

The current EDM parsing infrastructure does not take into account the possibility that a `<ReturnType>` element contains an `<Annotation>`.

This causes that a structure such as this (from a Cognos TM1 service):

```xml
<ReturnType Type="tm1.Hierarchy" Nullable="false">
	<Annotation Term="Core.Description">
		<String>The newly created all leaves hierarchy.</String>
	</Annotation>
</ReturnType>
```

...ends up messing the close tags, and closing the element containing the `<ReturnType>` before it should, causing the rest of the EDM to be ignored and the service being inaccessible.