### PR TITLE
Make ODataEntityCreateRequestImpl constructor public

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/communication/request/cud/ODataEntityCreateRequestImpl.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/communication/request/cud/ODataEntityCreateRequestImpl.java
@@ -60,7 +60,7 @@ public class ODataEntityCreateRequestImpl<E extends ClientEntity>
    * @param targetURI entity set URI.
    * @param entity entity to be created.
    */
-  ODataEntityCreateRequestImpl(final ODataClient odataClient, final URI targetURI, final E entity) {
+  public ODataEntityCreateRequestImpl(final ODataClient odataClient, final URI targetURI, final E entity) {
     super(odataClient, HttpMethod.POST, targetURI);
     this.entity = entity;
   }


### PR DESCRIPTION
With public constructor this class can be extended, same as e.g. ODataEntitySetIteratorRequestImpl or ODataEntityUpdateRequestImpl