### PR TITLE
Close http result on exceptions and when Odata Result closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .idea
 target
 bin
+*.iml
 *.bak
 classes
 .DS_Store

--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/communication/response/AbstractODataResponse.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/communication/response/AbstractODataResponse.java
@@ -32,6 +32,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.olingo.client.api.ODataClient;
 import org.apache.olingo.client.api.communication.request.batch.ODataBatchLineIterator;
@@ -103,7 +104,7 @@ public abstract class AbstractODataResponse implements ODataResponse {
    * Batch info (if to be batched).
    */
   protected ODataBatchController batchInfo = null;
-  
+
   private byte[] inputContent = null;
 
   public AbstractODataResponse(
@@ -244,10 +245,21 @@ public abstract class AbstractODataResponse implements ODataResponse {
 
   @Override
   public void close() {
+    closeHttpResponse();
     odataClient.getConfiguration().getHttpClientFactory().close(httpClient);
 
     if (batchInfo != null) {
       batchInfo.setValidBatch(false);
+    }
+  }
+
+  protected void closeHttpResponse() {
+    if(res != null && res instanceof CloseableHttpResponse) {
+      try {
+        ((CloseableHttpResponse) res).close();
+      } catch (IOException e) {
+        LOG.debug("Unable to close response: {}", res, e);
+      }
     }
   }
 


### PR DESCRIPTION
Current apache olingo implementation closes entire httpClient connection manager at the end of each odata response getBody method. 
If one try to use HttpConnectionFactory to cache thread safe httpclient instance it start leaking http connections.

This fix resolve this issue by closing  httpResponse objects properly.