### PR TITLE
Set up CodeQL scans

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,49 @@
+name: "CodeQL"
+
+on:
+  schedule:
+    - cron: '00 20 * * 3'
+  push:
+    branches: [master]
+    paths-ignore:
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'README'
+      - SECURITY.md'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'README'
+      - SECURITY.md'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
GitHub offers code scanning that is based on CodeQL (the same engine that is used in [LGTM.com](https://lgtm.com/)). Shortly, that's a static analysis tool that is able to catch various issues including security ones. Once enabled for pull requests, it would help with catching issues earlier.

The scan may be run via [GitHub Actions](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository#enabling-code-scanning-using-actions) for pull requests. Or, LGTM checks may be enabled, the instructions are [here](https://lgtm.com/help/lgtm/managing-automated-code-review).

This pull request adds a GitHub workflow that runs CodeQL scans for pull requests and the main branch. It is also scheduled to run `weekly on Wednesday at 8:00 PM`. There results will be available:

- in the "Security" tab for project maintainers
- in each pull request (only new alerts or fixed ones)