### PR TITLE
[OLINGO-1582] Remove CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
     <maven.bundle.plugin.version>2.5.4</maven.bundle.plugin.version>
     <hc.client.version>4.5.13</hc.client.version>
     <hc.core.version>4.4.11</hc.core.version>
-    <jackson.version>2.13.1</jackson.version>
-    <jackson-databind.version>2.13.1</jackson-databind.version>
+    <jackson.version>2.13.3</jackson.version>
+    <jackson-databind.version>2.13.3</jackson-databind.version>
     <aalto-xml.version>1.3.1</aalto-xml.version>
     <xmlunit.version>1.6</xmlunit.version>
     <mockito-all.version>1.9.5</mockito-all.version>


### PR DESCRIPTION
Hi @mibo !

Jackson 2.13.1 contains this vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518

The vulnerability is fixed in 2.13.3. Let's update.

Best regards

Daniel
