### PR TITLE
[OLINGO-1609] fix issue with multiple stream properties and full metadata

### DIFF
--- a/lib/client-core/src/main/java/org/apache/olingo/client/core/serialization/JsonEntityDeserializer.java
+++ b/lib/client-core/src/main/java/org/apache/olingo/client/core/serialization/JsonEntityDeserializer.java
@@ -226,6 +226,9 @@ public class JsonEntityDeserializer extends JsonDeserializer {
           toRemove.add(link.getTitle() + "@" + annotation.getTerm());
         }
       }
+      if (tree.get(link.getTitle() + Constants.JSON_TYPE) != null) {
+        toRemove.add(link.getTitle() + Constants.JSON_TYPE);
+      }
     }
 
     tree.remove(toRemove);

--- a/lib/client-core/src/test/java/org/apache/olingo/client/core/JsonDeserializerTest.java
+++ b/lib/client-core/src/test/java/org/apache/olingo/client/core/JsonDeserializerTest.java
@@ -1,0 +1,41 @@
+package org.apache.olingo.client.core;
+
+import org.apache.olingo.client.api.data.ResWrap;
+import org.apache.olingo.client.api.domain.ClientEntity;
+import org.apache.olingo.client.api.domain.ClientLink;
+import org.apache.olingo.client.api.serialization.ODataDeserializerException;
+import org.apache.olingo.client.core.serialization.ClientODataDeserializerImpl;
+import org.apache.olingo.client.core.serialization.ODataBinderImpl;
+import org.apache.olingo.commons.api.data.Entity;
+import org.apache.olingo.commons.api.format.ContentType;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonDeserializerTest {
+
+
+    /**
+     * Without the attached fix this test with the corresponding resource json will throw a {@link java.lang.IllegalArgumentException}
+     * with the message: 'Cannot build a primitive value for Stream'
+     *
+     * this is because the <streamproptitle>@odata.type key is incorrectly filtered by the previous implementation
+     */
+    @Test
+    public void testDeserializationStreamProperties() throws ODataDeserializerException {
+        try (InputStream inputStream = getClass().getResourceAsStream("Employee.json")) {
+            ClientODataDeserializerImpl clientODataDeserializer = new ClientODataDeserializerImpl(false, ContentType.JSON_FULL_METADATA);
+            ResWrap<Entity> entity = clientODataDeserializer.toEntity(inputStream);
+            ODataBinderImpl oDataBinder = new ODataBinderImpl(ODataClientFactory.getClient());
+            ClientEntity oDataEntity = oDataBinder.getODataEntity(entity);
+            List<ClientLink> mediaEditLinks = oDataEntity.getMediaEditLinks();
+            assertEquals(2, mediaEditLinks.size());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/lib/client-core/src/test/resources/org/apache/olingo/client/core/Employee.json
+++ b/lib/client-core/src/test/resources/org/apache/olingo/client/core/Employee.json
@@ -1,0 +1,19 @@
+{
+  "@odata.context": "http://odatae2etest.azurewebsites.net/javatest/DefaultService/$metadata#Employees/$entity",
+  "@odata.etag": "W/\"f557984846c2e312e155c9e8bede6186c4be9094b4edec2f5f32fe2a813f0cf1\"",
+  "@odata.id": "http://odatae2etest.azurewebsites.net/javatest/DefaultService/Employees(1)",
+  "Id@odata.type": "#Int64",
+  "Id": 1,
+  "FirstName": "Paul",
+  "LastName": "Mayor",
+  "DateOfBirth@odata.type": "#Date",
+  "DateOfBirth": "1973-08-17",
+  "Picture@odata.type": "#Stream",
+  "Picture@odata.mediaEtag": "W/\"32d1efc04f8aa14e828fa67d5161fa3664366e089b187402732a7c054ea2bc26\"",
+  "Picture@odata.mediaContentType": "image/jpeg",
+  "Picture@odata.mediaEditLink": "http://odatae2etest.azurewebsites.net/javatest/DefaultService/Employees(1)/Picture",
+  "Thumbnail@odata.type": "#Stream",
+  "Thumbnail@odata.mediaEtag": "W/\"7234c31b74af36899934883c9ff09ab0c70f8d0efdab9ac1a90010074f812931\"",
+  "Thumbnail@odata.mediaContentType": "image/jpeg",
+  "Thumbnail@odata.mediaEditLink": "http://odatae2etest.azurewebsites.net/javatest/DefaultService/Employees(1)/Thumbnail"
+}


### PR DESCRIPTION
The Deserializer has issues with multiple stream properties on a single entity.

This can be easily proven with the Test.

Am still missing an acutal issue thus this temporäry commit and PR format. Will fix as soon as I am granted access and create issue