### PR TITLE
Add support for Segment as Path from Odata v4.01

### DIFF
--- a/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmEntitySet.java
+++ b/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmEntitySet.java
@@ -31,4 +31,8 @@ public interface EdmEntitySet extends EdmBindingTarget {
    */
   boolean isIncludeInServiceDocument();
 
+  /**
+   * @return true if the entity set allows for the next segment to be the key.
+   */
+  boolean isKeyAsSegmentAllowed();
 }

--- a/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmNavigationProperty.java
+++ b/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/EdmNavigationProperty.java
@@ -60,4 +60,9 @@ public interface EdmNavigationProperty extends EdmElement, EdmAnnotatable {
   
   EdmOnDelete getOnDelete();
 
+  /**
+   * @return true if the entity set allows for the next segment to be the key.
+   */
+  boolean isKeyAsSegmentAllowed();
+
 }

--- a/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/provider/CsdlEntitySet.java
+++ b/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/provider/CsdlEntitySet.java
@@ -30,6 +30,9 @@ public class CsdlEntitySet extends CsdlBindingTarget {
   // Default for EntitySets is true
   private boolean includeInServiceDocument = true;
 
+  // Default for EntitySets is false
+  private boolean keyAsSegmentAllowed = false;
+
   @Override
   public CsdlEntitySet setName(final String name) {
     this.name = name;
@@ -81,7 +84,27 @@ public class CsdlEntitySet extends CsdlBindingTarget {
     this.includeInServiceDocument = includeInServiceDocument;
     return this;
   }
-  
+
+  /**
+   * Is this entity set allowed to be followed by a path variable.
+   *
+   * @return the boolean
+   */
+  public boolean isKeyAsSegmentAllowed() {
+    return keyAsSegmentAllowed;
+  }
+
+  /**
+   * Sets the path variable allowed parameter.
+   *
+   * @param keyAsSegmentAllowed whether path variables are allowed
+   * @return EntitySet with path variable boolean set.
+   */
+  public CsdlEntitySet setKeyAsSegmentAllowed(boolean keyAsSegmentAllowed) {
+    this.keyAsSegmentAllowed = keyAsSegmentAllowed;
+    return this;
+  }
+
   @Override
   public CsdlEntitySet setTitle(String title) {
     super.setTitle(title);

--- a/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/provider/CsdlNavigationProperty.java
+++ b/lib/commons-api/src/main/java/org/apache/olingo/commons/api/edm/provider/CsdlNavigationProperty.java
@@ -47,6 +47,9 @@ public class CsdlNavigationProperty extends CsdlAbstractEdmItem implements CsdlN
 
   private List<CsdlAnnotation> annotations = new ArrayList<CsdlAnnotation>();
 
+  // Default for EntitySets is false
+  private boolean keyAsSegmentAllowed = false;
+
   @Override
   public String getName() {
     return name;
@@ -239,6 +242,26 @@ public class CsdlNavigationProperty extends CsdlAbstractEdmItem implements CsdlN
    */
   public CsdlNavigationProperty setAnnotations(final List<CsdlAnnotation> annotations) {
     this.annotations = annotations;
+    return this;
+  }
+
+  /**
+   * Is this entity set allowed to be followed by a path variable.
+   *
+   * @return the boolean
+   */
+  public boolean isKeyAsSegmentAllowed() {
+    return keyAsSegmentAllowed;
+  }
+
+  /**
+   * Sets the path variable allowed parameter.
+   *
+   * @param keyAsSegmentAllowed whether path variables are allowed
+   * @return EntitySet with path variable boolean set.
+   */
+  public CsdlNavigationProperty setKeyAsSegmentAllowed(boolean keyAsSegmentAllowed) {
+    this.keyAsSegmentAllowed = keyAsSegmentAllowed;
     return this;
   }
 }

--- a/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmEntitySetImpl.java
+++ b/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmEntitySetImpl.java
@@ -37,4 +37,8 @@ public class EdmEntitySetImpl extends AbstractEdmBindingTarget implements EdmEnt
     return entitySet.isIncludeInServiceDocument();
   }
 
+  @Override
+  public boolean isKeyAsSegmentAllowed() {
+    return entitySet.isKeyAsSegmentAllowed();
+  }
 }

--- a/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmNavigationPropertyImpl.java
+++ b/lib/commons-core/src/main/java/org/apache/olingo/commons/core/edm/EdmNavigationPropertyImpl.java
@@ -127,4 +127,9 @@ public class EdmNavigationPropertyImpl extends AbstractEdmNamed implements EdmNa
     CsdlOnDelete csdlOnDelete = navigationProperty.getOnDelete();
     return csdlOnDelete != null ? new EdmOnDeleteImpl(edm, csdlOnDelete) : null;
   }
+
+  @Override
+  public boolean isKeyAsSegmentAllowed() {
+    return navigationProperty.isKeyAsSegmentAllowed();
+  }
 }

--- a/lib/server-tecsvc/src/main/java/org/apache/olingo/server/tecsvc/provider/ContainerProvider.java
+++ b/lib/server-tecsvc/src/main/java/org/apache/olingo/server/tecsvc/provider/ContainerProvider.java
@@ -730,7 +730,31 @@ public class ContainerProvider {
       return new CsdlEntitySet()
           .setName("ESStreamOnComplexProp")
           .setType(EntityTypeProvider.nameETStreamOnComplexProp);
-      } 
+    } else if (name.equals("ESKeyAsSegmentString")) {
+      return new CsdlEntitySet()
+          .setName("ESKeyAsSegmentString")
+          .setType(EntityTypeProvider.nameETKeyAsSegmentString)
+          .setKeyAsSegmentAllowed(true);
+    } else if (name.equals("ESKeyAsSegmentInt")) {
+      return new CsdlEntitySet()
+          .setName("ESKeyAsSegmentInt")
+          .setType(EntityTypeProvider.nameETKeyAsSegmentInt)
+          .setKeyAsSegmentAllowed(true);
+    } else if (name.equals("ESComplexKeyAsSegment")) {
+      return new CsdlEntitySet()
+          .setName("ESComplexKeyAsSegment")
+          .setType(EntityTypeProvider.nameETComplexKeyAsSegment)
+          .setKeyAsSegmentAllowed(true);
+      } else if (name.equals("ESKeyAsSegmentStringNavKeyAsSegment")) {
+      return new CsdlEntitySet()
+          .setName("ESKeyAsSegmentStringNavKeyAsSegment")
+          .setType(EntityTypeProvider.nameETKeyAsSegmentStringNavKeyAsSegment)
+          .setKeyAsSegmentAllowed(true)
+          .setNavigationPropertyBindings(Arrays.asList(new CsdlNavigationPropertyBinding()
+            .setPath(PropertyProvider.navPropertyKeyAsSegment.getName())
+            .setTarget("ESKeyAsSegmentString")
+          ));
+      }
     }
     return null;
   }

--- a/lib/server-tecsvc/src/main/java/org/apache/olingo/server/tecsvc/provider/EntityTypeProvider.java
+++ b/lib/server-tecsvc/src/main/java/org/apache/olingo/server/tecsvc/provider/EntityTypeProvider.java
@@ -100,6 +100,18 @@ public class EntityTypeProvider {
   
   public static final FullQualifiedName nameETStreamOnComplexProp = 
       new FullQualifiedName(SchemaProvider.NAMESPACE, "ETStreamOnComplexProp");
+
+  public static final FullQualifiedName nameETKeyAsSegmentString =
+          new FullQualifiedName(SchemaProvider.NAMESPACE, "ETKeyAsSegmentString");
+
+  public static final FullQualifiedName nameETKeyAsSegmentInt =
+          new FullQualifiedName(SchemaProvider.NAMESPACE, "ETKeyAsSegmentInt");
+
+  public static final FullQualifiedName nameETComplexKeyAsSegment =
+          new FullQualifiedName(SchemaProvider.NAMESPACE, "ETComplexKeyAsSegment");
+
+  public static final FullQualifiedName nameETKeyAsSegmentStringNavKeyAsSegment =
+          new FullQualifiedName(SchemaProvider.NAMESPACE, "ETKeyAsSegmentStringNavKeyAsSegment");
   
   public CsdlEntityType getEntityType(final FullQualifiedName entityTypeName) throws ODataException {
     if(entityTypeName.equals(nameETAllPrimDefaultValues)){        
@@ -574,6 +586,37 @@ public class EntityTypeProvider {
               PropertyProvider.propertyInt32, PropertyProvider.propertyEntityStream,
               PropertyProvider.propertyCompWithStream_CTWithStreamProp
               ));
+    } else if (entityTypeName.equals(nameETKeyAsSegmentString)) {
+      return new CsdlEntityType()
+              .setName("ETKeyAsSegmentString")
+              .setKey(Arrays.asList(
+                      new CsdlPropertyRef().setName("PropertyString")))
+              .setProperties(Arrays.asList(
+                      PropertyProvider.propertyString_NotNullable));
+    } else if (entityTypeName.equals(nameETKeyAsSegmentInt)) {
+      return new CsdlEntityType()
+              .setName("ETKeyAsSegmentInt")
+              .setKey(Arrays.asList(
+                      new CsdlPropertyRef().setName("PropertyInt16")))
+              .setProperties(Arrays.asList(
+                      PropertyProvider.propertyInt16_NotNullable));
+    } else if (entityTypeName.equals(nameETComplexKeyAsSegment)) {
+      return new CsdlEntityType()
+              .setName("ETComplexKeyAsSegment")
+              .setKey(Arrays.asList(
+                      new CsdlPropertyRef().setName("PropertyString"),
+                      new CsdlPropertyRef().setName("PropertyInt16")))
+              .setProperties(Arrays.asList(
+                      PropertyProvider.propertyString_NotNullable,
+                      PropertyProvider.propertyInt16_NotNullable));
+    } else if(entityTypeName.equals(nameETKeyAsSegmentStringNavKeyAsSegment)) {
+      return new CsdlEntityType()
+              .setName(nameETKeyAsSegmentStringNavKeyAsSegment.getName())
+              .setKey(Arrays.asList(
+                      new CsdlPropertyRef().setName("PropertyString")))
+              .setProperties(Arrays.asList(
+                      PropertyProvider.propertyString_NotNullable))
+              .setNavigationProperties(Arrays.asList(PropertyProvider.navPropertyKeyAsSegment));
     }
     return null;
   }

--- a/lib/server-tecsvc/src/main/java/org/apache/olingo/server/tecsvc/provider/PropertyProvider.java
+++ b/lib/server-tecsvc/src/main/java/org/apache/olingo/server/tecsvc/provider/PropertyProvider.java
@@ -1051,4 +1051,9 @@ public class PropertyProvider {
       .setName("NavPropertyETStreamOnComplexPropMany")
       .setType(EntityTypeProvider.nameETStream)
       .setCollection(true);
-}
+
+  public static final CsdlNavigationProperty navPropertyKeyAsSegment = new CsdlNavigationProperty()
+      .setName("NavPropertyKeyAsSegment")
+      .setType(EntityTypeProvider.nameETKeyAsSegmentStringNavKeyAsSegment)
+      .setKeyAsSegmentAllowed(true);
+  }

--- a/lib/server-test/src/test/java/org/apache/olingo/server/core/uri/parser/ResourcePathParserTest.java
+++ b/lib/server-test/src/test/java/org/apache/olingo/server/core/uri/parser/ResourcePathParserTest.java
@@ -196,6 +196,30 @@ public class ResourcePathParserTest {
   }
 
   @Test
+  public void testPathVariables() {
+    testRes.run("ESKeyAsSegmentString/thisIsAKey")
+            .isEntitySet("ESKeyAsSegmentString")
+            .isKeyPredicate(0, "PropertyString", "'thisIsAKey'");
+
+    testRes.run("ESKeyAsSegmentInt/1001")
+            .isEntitySet("ESKeyAsSegmentInt")
+            .isKeyPredicate(0, "PropertyInt16", "1001");
+
+    testUri.runEx("ESKeyAsSegmentString('thisIsAKey')/thisIsAnotherKey").isExSemantic(MessageKeys.PROPERTY_NOT_IN_TYPE);
+    testUri.runEx("ESComplexKeyAsSegment/thisIsAKey").isExSemantic(MessageKeys.PROPERTY_AFTER_COLLECTION);
+  }
+
+  @Test
+  public void testPathVariablesNavigation() {
+    testRes.run("ESKeyAsSegmentStringNavKeyAsSegment/thisIsAKey/NavPropertyKeyAsSegment/navKey")
+            .isEntitySet("ESKeyAsSegmentStringNavKeyAsSegment")
+            .isKeyPredicate(0, "PropertyString", "'thisIsAKey'")
+            .n() // this means move to the next property.
+            .isNavProperty("NavPropertyKeyAsSegment", PropertyProvider.navPropertyKeyAsSegment.getTypeFQN(), false)
+            .isKeyPredicate(0, "PropertyString", "'navKey'");
+  }
+
+  @Test
   public void esNameParaKeys() throws Exception {
     testRes.run("ESAllKey(PropertyString='O''Neil',PropertyBoolean=true,PropertyByte=255,"
         + "PropertySByte=-128,PropertyInt16=-32768,PropertyInt32=-2147483648,"


### PR DESCRIPTION
Related Ticket: https://issues.apache.org/jira/browse/OLINGO-1630

### Summary
Introduced in OData v4.01, OData supports "Key as Segment": https://www.odata.org/blog/OData-401-Committee-Spec-Published/

> Key as Segment – Common semantics for representing keys within a URL as a segment, rather than enclosed in parenthesis.

It appears to work fine from the client-side, but the server-side implementation is missing. In this proposal, we suggest adding optional support for the Key as Segment capability to CsdlEntitySet through `setKeyAsSegmentAllowed`. The goal was to add support but make it an opt-in feature to prevent breaking existing implementations.

 

#### Link to specification:

https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31360937 