### PR TITLE
Serialization error when using sum on decimal values in aggregate expression

### DIFF
--- a/dist/android-lib/pom.xml
+++ b/dist/android-lib/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-dist</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/dist/client-lib/pom.xml
+++ b/dist/client-lib/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-dist</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/dist/javadoc/pom.xml
+++ b/dist/javadoc/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-dist</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/dist/server-lib-ext/pom.xml
+++ b/dist/server-lib-ext/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-dist</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/dist/server-lib/pom.xml
+++ b/dist/server-lib/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-dist</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ext/client-android/pom.xml
+++ b/ext/client-android/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-ext</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ext/client-proxy/pom.xml
+++ b/ext/client-proxy/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-ext</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ext/karaf/karaf-features/pom.xml
+++ b/ext/karaf/karaf-features/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-karaf</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
     <build>

--- a/ext/karaf/karaf-fit/pom.xml
+++ b/ext/karaf/karaf-fit/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-karaf</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <dependencies>

--- a/ext/karaf/karaf-fit/src/test/java/org/apache/olingo/osgi/itests/server/CarServiceTest.java
+++ b/ext/karaf/karaf-fit/src/test/java/org/apache/olingo/osgi/itests/server/CarServiceTest.java
@@ -96,7 +96,7 @@ public class CarServiceTest extends OlingoOSGiTestSupport {
         return new Option[] {
             olingoBaseConfig(),
             features(olingoUrl, "olingo-server", "olingo-client"),
-            mavenBundle("org.apache.olingo", "odata-server-osgi-sample", "5.0.1-SNAPSHOT"),
+            mavenBundle("org.apache.olingo", "odata-server-osgi-sample", "5.0.2-SNAPSHOT"),
             logLevel(LogLevel.INFO)
         };
     }

--- a/ext/karaf/pom.xml
+++ b/ext/karaf/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-ext</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ext/pojogen-maven-plugin/pom.xml
+++ b/ext/pojogen-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-ext</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/fit/pom.xml
+++ b/fit/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/fit/src/test/java/org/apache/olingo/fit/tecsvc/http/ODataVersionConformanceITCase.java
+++ b/fit/src/test/java/org/apache/olingo/fit/tecsvc/http/ODataVersionConformanceITCase.java
@@ -96,9 +96,10 @@ public class ODataVersionConformanceITCase extends AbstractBaseTestITCase {
     connection.setRequestProperty(HttpHeader.ODATA_MAX_VERSION, "5.0");
     connection.connect();
 
+    assertEquals(HttpStatusCode.OK.getStatusCode(), connection.getResponseCode());
     assertEquals("4.0", connection.getHeaderField(HttpHeader.ODATA_VERSION));
 
-    final String content = IOUtils.toString(connection.getErrorStream(), Charset.defaultCharset());
+    final String content = IOUtils.toString(connection.getInputStream(), Charset.defaultCharset());
     assertNotNull(content);
   }
 
@@ -112,10 +113,11 @@ public class ODataVersionConformanceITCase extends AbstractBaseTestITCase {
     connection.setRequestProperty(HttpHeader.ODATA_MAX_VERSION, "5.0");
     connection.connect();
 
+    assertEquals(HttpStatusCode.OK.getStatusCode(), connection.getResponseCode());
     assertEquals("4.0", connection.getHeaderField(HttpHeader.ODATA_VERSION));
 
-    final String content = IOUtils.toString(connection.getErrorStream(), Charset.defaultCharset());
-    assertNotNull(content);;
+    final String content = IOUtils.toString(connection.getInputStream(), Charset.defaultCharset());
+    assertNotNull(content);
   }
   
   @Test

--- a/lib/client-api/pom.xml
+++ b/lib/client-api/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/client-core/pom.xml
+++ b/lib/client-core/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/commons-api/pom.xml
+++ b/lib/commons-api/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/commons-core/pom.xml
+++ b/lib/commons-core/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/server-api/pom.xml
+++ b/lib/server-api/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/server-api/src/main/java/org/apache/olingo/server/api/uri/queryoption/apply/AggregateExpression.java
+++ b/lib/server-api/src/main/java/org/apache/olingo/server/api/uri/queryoption/apply/AggregateExpression.java
@@ -19,6 +19,7 @@
 package org.apache.olingo.server.api.uri.queryoption.apply;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
@@ -85,9 +86,26 @@ public interface AggregateExpression extends Expression {
    */
   Set<String> getDynamicProperties();
 
+
+  /**
+   * Gets the dynamic properties for aggregation expression.
+   * @return the set of properties
+   */
+  Map<String, AggregateExpressionDynamicPropertyOptions> getDynamicPropertiesWithOptions();
+
+
   /**
    * Adds the dynamic property for aggregation expression.
    * @param name an identifier
    */
   void addDynamicProperty(String name);
+
+    /**
+   * Adds the dynamic property for aggregation expression.
+   * @param name an identifier
+   * @param options the options for the dynamic property
+   */
+  void addDynamicProperty(String name, AggregateExpressionDynamicPropertyOptions options);
+
 }
+

--- a/lib/server-api/src/main/java/org/apache/olingo/server/api/uri/queryoption/apply/AggregateExpressionDynamicPropertyOptions.java
+++ b/lib/server-api/src/main/java/org/apache/olingo/server/api/uri/queryoption/apply/AggregateExpressionDynamicPropertyOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.olingo.server.api.uri.queryoption.apply;
+
+/**
+ * Represents the options for dynamic properties in aggregate expressions.
+ */
+public class AggregateExpressionDynamicPropertyOptions {
+    public Integer scale;
+}

--- a/lib/server-core-ext/pom.xml
+++ b/lib/server-core-ext/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <dependencies>

--- a/lib/server-core/pom.xml
+++ b/lib/server-core/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/server-core/src/main/java/org/apache/olingo/server/core/uri/queryoption/apply/AggregateExpressionImpl.java
+++ b/lib/server-core/src/main/java/org/apache/olingo/server/core/uri/queryoption/apply/AggregateExpressionImpl.java
@@ -20,8 +20,9 @@ package org.apache.olingo.server.core.uri.queryoption.apply;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
@@ -29,6 +30,7 @@ import org.apache.olingo.server.api.ODataApplicationException;
 import org.apache.olingo.server.api.uri.UriInfo;
 import org.apache.olingo.server.api.uri.UriResource;
 import org.apache.olingo.server.api.uri.queryoption.apply.AggregateExpression;
+import org.apache.olingo.server.api.uri.queryoption.apply.AggregateExpressionDynamicPropertyOptions;
 import org.apache.olingo.server.api.uri.queryoption.expression.Expression;
 import org.apache.olingo.server.api.uri.queryoption.expression.ExpressionVisitException;
 import org.apache.olingo.server.api.uri.queryoption.expression.ExpressionVisitor;
@@ -45,7 +47,7 @@ public class AggregateExpressionImpl implements AggregateExpression {
   private String alias;
   private AggregateExpression inlineAggregateExpression;
   private List<AggregateExpression> from = new ArrayList<>();
-  private Set<String> dynamicProperties = new HashSet<>();
+  private Map<String, AggregateExpressionDynamicPropertyOptions> dynamicProperties = new HashMap<>();
 
   @Override
   public List<UriResource> getPath() {
@@ -125,11 +127,21 @@ public class AggregateExpressionImpl implements AggregateExpression {
   
   @Override
   public Set<String> getDynamicProperties() {
-    return Collections.unmodifiableSet(dynamicProperties);
+    return Collections.unmodifiableSet(dynamicProperties.keySet());
   }
 
   @Override
   public void addDynamicProperty(String name) {
-    dynamicProperties.add(name);
+    dynamicProperties.put(name, null);
+  }
+
+  @Override
+  public void addDynamicProperty(String name, AggregateExpressionDynamicPropertyOptions options) {
+    dynamicProperties.put(name, options);
+  }
+
+  @Override
+  public Map<String, AggregateExpressionDynamicPropertyOptions> getDynamicPropertiesWithOptions() {
+    return Collections.unmodifiableMap(dynamicProperties);
   }
 }

--- a/lib/server-tecsvc/pom.xml
+++ b/lib/server-tecsvc/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/server-test/pom.xml
+++ b/lib/server-test/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-lib</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/lib/server-test/src/test/java/org/apache/olingo/server/core/ODataHandlerImplTest.java
+++ b/lib/server-test/src/test/java/org/apache/olingo/server/core/ODataHandlerImplTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.apache.olingo</groupId>
   <artifactId>odata-parent</artifactId>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Olingo-OData</name>

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,11 @@
           <artifactId>cobertura-maven-plugin</artifactId>
           <version>2.7</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/samples/client/pom.xml
+++ b/samples/client/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-samples</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/samples/osgi/server/pom.xml
+++ b/samples/osgi/server/pom.xml
@@ -30,7 +30,7 @@ under the License.
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-samples</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-parent</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/samples/server/pom.xml
+++ b/samples/server/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>org.apache.olingo</groupId>
 		<artifactId>odata-samples</artifactId>
-		<version>5.0.1-SNAPSHOT</version>
+		<version>5.0.2-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/samples/tutorials/p0_all/pom.xml
+++ b/samples/tutorials/p0_all/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId} Webapp</name>
 
@@ -35,7 +35,7 @@
 
     <properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p10_media/pom.xml
+++ b/samples/tutorials/p10_media/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-Media</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p11_batch/pom.xml
+++ b/samples/tutorials/p11_batch/pom.xml
@@ -25,13 +25,13 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-Batch</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
   <properties>
     <javax.version>2.5</javax.version>
-    <odata.version>5.0.1-SNAPSHOT</odata.version>
+    <odata.version>5.0.2-SNAPSHOT</odata.version>
     <slf4j.version>1.7.7</slf4j.version>
     <project.source>17</project.source>
     <compiler.plugin.version>3.11.0</compiler.plugin.version>

--- a/samples/tutorials/p12_deep_insert/pom.xml
+++ b/samples/tutorials/p12_deep_insert/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-DeepInsert</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p12_deep_insert_preparation/pom.xml
+++ b/samples/tutorials/p12_deep_insert_preparation/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-DeepInsertPreparation</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p1_read/pom.xml
+++ b/samples/tutorials/p1_read/pom.xml
@@ -25,7 +25,7 @@
   <groupId>my.group.id</groupId>
 	<artifactId>DemoService-Read</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p2_readep/pom.xml
+++ b/samples/tutorials/p2_readep/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-ReadEp</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -19,7 +19,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p3_write/pom.xml
+++ b/samples/tutorials/p3_write/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-Write</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p4_navigation/pom.xml
+++ b/samples/tutorials/p4_navigation/pom.xml
@@ -25,7 +25,7 @@
   <groupId>my.group.id</groupId>
   <artifactId>DemoService-Navigation</artifactId>
   <packaging>war</packaging>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p5_queryoptions-tcs/pom.xml
+++ b/samples/tutorials/p5_queryoptions-tcs/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-QueryOptions-TCS</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p6_queryoptions-es/pom.xml
+++ b/samples/tutorials/p6_queryoptions-es/pom.xml
@@ -25,7 +25,7 @@
   <groupId>my.group.id</groupId>
   <artifactId>DemoService-QueryOptions-ES</artifactId>
   <packaging>war</packaging>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p7_queryoptions-o/pom.xml
+++ b/samples/tutorials/p7_queryoptions-o/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-QueryOptions-O</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p8_queryoptions-f/pom.xml
+++ b/samples/tutorials/p8_queryoptions-f/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-QueryOptions-F</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId} Webapp</name>
 
@@ -35,7 +35,7 @@
 
     <properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p9_action/pom.xml
+++ b/samples/tutorials/p9_action/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-Action</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/p9_action_preparation/pom.xml
+++ b/samples/tutorials/p9_action_preparation/pom.xml
@@ -25,7 +25,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-ActionPreparation</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -35,7 +35,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/pe_streaming/pom.xml
+++ b/samples/tutorials/pe_streaming/pom.xml
@@ -9,7 +9,7 @@
 	<groupId>my.group.id</groupId>
 	<artifactId>DemoService-Streaming</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.1-SNAPSHOT</version>
+	<version>5.0.2-SNAPSHOT</version>
 
 	<name>${project.artifactId}-Webapp</name>
 
@@ -19,7 +19,7 @@
 
 	<properties>
 		<javax.version>2.5</javax.version>
-		<odata.version>5.0.1-SNAPSHOT</odata.version>
+		<odata.version>5.0.2-SNAPSHOT</odata.version>
 		<slf4j.version>1.7.7</slf4j.version>
 	</properties>
 

--- a/samples/tutorials/pom.xml
+++ b/samples/tutorials/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.apache.olingo</groupId>
     <artifactId>odata-samples</artifactId>
-    <version>5.0.1-SNAPSHOT</version>
+    <version>5.0.2-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
Fix: Serialization error when using sum on decimal values in aggregate expressions

This PR addresses a bug where using the sum aggregation on decimal properties would lead to a JSON serialization error due to missing or inconsistent scale information.

To resolve this, support for dynamic property options (e.g., scale) was added, allowing the aggregation parser and type constructor to handle decimal precision correctly during aggregation.

Key changes:

Introduced support for dynamic property options in aggregate expressions.

Ensured scale is preserved and correctly applied during parsing and result construction.

Improved compatibility with JSON serialization by ensuring consistent type metadata.

This fix is essential for systems that rely on precise decimal aggregation and downstream serialization (e.g., REST APIs or JSON-based storage).